### PR TITLE
Fixed printf "\033[H" error on nushell

### DIFF
--- a/src/clear-buffer.js
+++ b/src/clear-buffer.js
@@ -1,2 +1,2 @@
-exports.clearBuffer = ({ app, uid }, cmd = 'printf "\\\\033[H"') =>
+exports.clearBuffer = ({ app, uid }, cmd = 'printf "\\033[H"') =>
   app.sessions.get(uid).write(`${cmd} \r`)

--- a/src/clear-buffer.js
+++ b/src/clear-buffer.js
@@ -1,2 +1,2 @@
-exports.clearBuffer = ({ app, uid }, cmd = 'printf "\\033[H"') =>
+exports.clearBuffer = ({ app, uid }, cmd = 'printf "\\\\033[H"') =>
   app.sessions.get(uid).write(`${cmd} \r`)

--- a/src/shells.js
+++ b/src/shells.js
@@ -3,5 +3,6 @@ exports.KNOWN_SHELLS = {
   node: { separator: '; ', clearCommand: 'console.clear();' },
   cmd: { separator: ' & ', clearCommand: 'cls' },
   fish: { separator: ' & ', clearCommand: 'clear' },
-  fallback: { separator: ' && ', clearCommand: 'printf "\\\\033[H"' },
+  nu: { separator: ' && ', clearCommand: 'printf "\\\\033[H"' },
+  fallback: { separator: ' && ', clearCommand: 'printf "\\033[H"' },
 }

--- a/src/shells.js
+++ b/src/shells.js
@@ -3,5 +3,5 @@ exports.KNOWN_SHELLS = {
   node: { separator: '; ', clearCommand: 'console.clear();' },
   cmd: { separator: ' & ', clearCommand: 'cls' },
   fish: { separator: ' & ', clearCommand: 'clear' },
-  fallback: { separator: ' && ', clearCommand: 'printf "\\033[H"' },
+  fallback: { separator: ' && ', clearCommand: 'printf "\\\\033[H"' },
 }


### PR DESCRIPTION
The following error occurs when I use [nushell](https://www.nushell.sh)

Error: nu::parser::parse_mismatch (link)

  × Parse mismatch during operation.
   ╭─[entry #1:1:1]
 1 │ printf "\033[H" 
   ·          ───┬──
   ·             ╰── expected supported escape character
   ╰────
 